### PR TITLE
Ensure instance metadata step is not skipped

### DIFF
--- a/tfw
+++ b/tfw
@@ -281,7 +281,7 @@ EOGROUPSUDO
 }
 
 __bootstrap_instance_metadata() {
-  cat >"${inst_conf}" <<EOCONF
+  cat >"${ETCDIR}/default/travis-instance-local" <<EOCONF
 # generated $(date -u)
 export TRAVIS_INSTANCE_ID=$(__get_instance_id)
 export TRAVIS_INSTANCE_IPV4=$(__get_instance_ipv4)

--- a/tfw
+++ b/tfw
@@ -281,12 +281,6 @@ EOGROUPSUDO
 }
 
 __bootstrap_instance_metadata() {
-  local inst_conf="${ETCDIR}/default/travis-instance-local"
-  if [[ -f "${inst_conf}" ]]; then
-    __info "found ${inst_conf}; skipping metadata setup"
-    return
-  fi
-
   cat >"${inst_conf}" <<EOCONF
 # generated $(date -u)
 export TRAVIS_INSTANCE_ID=$(__get_instance_id)


### PR DESCRIPTION
since the bootstrap process may run at various stages, and it's a
tell-don't-ask operation anyway.