### PR TITLE
Ensure log records include a hint about origin

### DIFF
--- a/bin/tfw-admin-clean-containers
+++ b/bin/tfw-admin-clean-containers
@@ -38,7 +38,8 @@ def main(argv=sys.argv[:], env=os.environ):
 
 
 class L2metFormatter(logging.Formatter):
-    _l2met_fmt = 'time={now} level={level} msg={msg!r}{kwargs}'
+    _l2met_fmt = 'admin-clean-containers time={now} level={level} ' \
+                 'msg={msg!r}{kwargs}'
 
     def format(self, record):
         rec = {}


### PR DESCRIPTION
to differentiate from the logs sent via `tfw admin-run-docker`