### PR TITLE
Remove now-redundant identifier from log format

### DIFF
--- a/bin/tfw-admin-clean-containers
+++ b/bin/tfw-admin-clean-containers
@@ -38,8 +38,7 @@ def main(argv=sys.argv[:], env=os.environ):
 
 
 class L2metFormatter(logging.Formatter):
-    _l2met_fmt = 'admin-clean-containers time={now} level={level} ' \
-                 'msg={msg!r}{kwargs}'
+    _l2met_fmt = 'time={now} level={level} msg={msg!r}{kwargs}'
 
     def format(self, record):
         rec = {}


### PR DESCRIPTION
since the "program" syslog identifier is now correctly reflecting what's
running