### PR TITLE
Remove automatic kernel upgrade on xenial

### DIFF
--- a/bin/tfw
+++ b/bin/tfw
@@ -751,10 +751,6 @@ __run_admin-bootstrap() {
   __run_admin-rsyslog "${TFW_SYSLOG_ADDRESS}"
   __run_admin-duo "${TFW_DUO_CONF}"
   __run_admin-librato
-
-  if [[ "${DIST}" == xenial ]]; then
-    __run_admin-upgrade-kernel "${TFW_KERNEL_VERSION}"
-  fi
 }
 
 def admin-users "<username:github-login> [username:github-login, ]


### PR DESCRIPTION
because it is not cleanly installing in all cases and maybe we don't
really care anymore (??)