### PR TITLE
Defer execution of shell command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PREFIX ?= /usr/local
 SHELLCHECK_URL := https://www.googleapis.com/download/storage/v1/b/shellcheck/o/shellcheck-v0.4.7.linux.x86_64.tar.xz?alt=media
 SHFMT_URL := https://github.com/mvdan/sh/releases/download/v2.2.0/shfmt_v2.2.0_linux_amd64
 
-TOP := $(shell git rev-parse --show-toplevel)
+TOP = $(shell git rev-parse --show-toplevel)
 
 .PHONY: all
 all: test


### PR DESCRIPTION
The following error occurs when `tfw` is installed from
a tarball:

```
fatal: Not a git repository (or any of the parent directories): .git

```

This ensures the failing command is only executed when the variable is
referenced.

```
% cat <<'EOF' >Makefile
FOO = $(shell foo)

.PHONY: bar
bar:
        @echo "not using foo"

.PHONY: baz
baz:
        @echo using FOO: $(FOO)
EOF

% make bar
not using foo

% make baz
make: foo: Command not found
using FOO:
```